### PR TITLE
Add home tab with recommended destinations

### DIFF
--- a/lib/app_providers.dart
+++ b/lib/app_providers.dart
@@ -5,6 +5,11 @@ import 'features/plan/data/repositories/plan_repository_impl.dart';
 import 'features/plan/data/datasource/plan_remote_data_source.dart';
 // 실제 구현체 import
 import 'features/plan/data/datasource/plan_remote_data_source_impl.dart';
+import 'features/home/domain/usecases/get_destinations_use_case.dart';
+import 'features/home/domain/repositories/home_repository.dart';
+import 'features/home/data/repositories/home_repository_impl.dart';
+import 'features/home/data/datasource/home_remote_data_source.dart';
+import 'features/home/data/datasource/home_remote_data_source_impl.dart';
 
 final appProviders = [
   // PlanRemoteDataSource Provider 추가 (구현체로 대체)
@@ -16,6 +21,17 @@ final appProviders = [
   ),
   Provider<GetPlansUseCase>(
     create: (context) => GetPlansUseCase(context.read<PlanRepository>()),
+  ),
+  // Home feature providers
+  Provider<HomeRemoteDataSource>(create: (_) => HomeRemoteDataSourceImpl()),
+  Provider<HomeRepository>(
+    create: (context) => HomeRepositoryImpl(
+      context.read<HomeRemoteDataSource>(),
+    ),
+  ),
+  Provider<GetDestinationsUseCase>(
+    create: (context) =>
+        GetDestinationsUseCase(context.read<HomeRepository>()),
   ),
   // 다른 Provider도 여기에 추가
 ];

--- a/lib/core/widgets/app_scaffold.dart
+++ b/lib/core/widgets/app_scaffold.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'bottom_nav_bar.dart';
 import '../../features/plan/presentation/pages/plan_page.dart';
+import '../../features/home/presentation/pages/home_page.dart';
 
 class AppScaffold extends StatefulWidget {
   const AppScaffold({super.key});
@@ -10,10 +11,10 @@ class AppScaffold extends StatefulWidget {
 }
 
 class _AppScaffoldState extends State<AppScaffold> {
-  int _selectedIndex = 2;
+  int _selectedIndex = 0;
 
   static final _pages = <Widget>[
-    Center(child: Text('Home')),
+    HomePage(),
     Center(child: Text('Diary')),
     PlanPage(),
     Center(child: Text('Chat')),

--- a/lib/features/home/data/datasource/home_remote_data_source.dart
+++ b/lib/features/home/data/datasource/home_remote_data_source.dart
@@ -1,0 +1,5 @@
+import '../../domain/entities/destination_entity.dart';
+
+abstract class HomeRemoteDataSource {
+  Future<List<DestinationEntity>> fetchRecommendedDestinations();
+}

--- a/lib/features/home/data/datasource/home_remote_data_source_impl.dart
+++ b/lib/features/home/data/datasource/home_remote_data_source_impl.dart
@@ -1,0 +1,11 @@
+import 'home_remote_data_source.dart';
+import '../dummy_home_data.dart';
+import '../../domain/entities/destination_entity.dart';
+
+class HomeRemoteDataSourceImpl implements HomeRemoteDataSource {
+  @override
+  Future<List<DestinationEntity>> fetchRecommendedDestinations() async {
+    // In a real app this would fetch from network
+    return DummyHomeData.fetchRecommendedDestinations();
+  }
+}

--- a/lib/features/home/data/dummy_home_data.dart
+++ b/lib/features/home/data/dummy_home_data.dart
@@ -1,0 +1,26 @@
+import '../domain/entities/destination_entity.dart';
+
+class DummyHomeData {
+  static List<DestinationEntity> fetchRecommendedDestinations() => [
+    DestinationEntity(
+      id: 'dest-1',
+      title: '제주도',
+      imageUrl: 'assets/flags/jeonju.png',
+    ),
+    DestinationEntity(
+      id: 'dest-2',
+      title: '스페인',
+      imageUrl: 'assets/flags/spain.png',
+    ),
+    DestinationEntity(
+      id: 'dest-3',
+      title: '발리',
+      imageUrl: 'assets/flags/bali.png',
+    ),
+    DestinationEntity(
+      id: 'dest-4',
+      title: '스위스',
+      imageUrl: 'assets/flags/switzerland.png',
+    ),
+  ];
+}

--- a/lib/features/home/data/repositories/home_repository_impl.dart
+++ b/lib/features/home/data/repositories/home_repository_impl.dart
@@ -1,0 +1,13 @@
+import '../../domain/entities/destination_entity.dart';
+import '../../domain/repositories/home_repository.dart';
+import '../datasource/home_remote_data_source.dart';
+
+class HomeRepositoryImpl implements HomeRepository {
+  final HomeRemoteDataSource remoteDataSource;
+  HomeRepositoryImpl(this.remoteDataSource);
+
+  @override
+  Future<List<DestinationEntity>> getRecommendedDestinations() {
+    return remoteDataSource.fetchRecommendedDestinations();
+  }
+}

--- a/lib/features/home/domain/entities/destination_entity.dart
+++ b/lib/features/home/domain/entities/destination_entity.dart
@@ -1,0 +1,11 @@
+class DestinationEntity {
+  final String id;
+  final String title;
+  final String imageUrl;
+
+  DestinationEntity({
+    required this.id,
+    required this.title,
+    required this.imageUrl,
+  });
+}

--- a/lib/features/home/domain/repositories/home_repository.dart
+++ b/lib/features/home/domain/repositories/home_repository.dart
@@ -1,0 +1,5 @@
+import '../entities/destination_entity.dart';
+
+abstract class HomeRepository {
+  Future<List<DestinationEntity>> getRecommendedDestinations();
+}

--- a/lib/features/home/domain/usecases/get_destinations_use_case.dart
+++ b/lib/features/home/domain/usecases/get_destinations_use_case.dart
@@ -1,0 +1,14 @@
+import '../../../../core/usecases/common_use_case.dart';
+import '../entities/destination_entity.dart';
+import '../repositories/home_repository.dart';
+
+class GetDestinationsUseCase
+    implements CommonUseCase<List<DestinationEntity>, void> {
+  final HomeRepository repository;
+  GetDestinationsUseCase(this.repository);
+
+  @override
+  Future<List<DestinationEntity>> call(void params) {
+    return repository.getRecommendedDestinations();
+  }
+}

--- a/lib/features/home/presentation/controllers/home_controller.dart
+++ b/lib/features/home/presentation/controllers/home_controller.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/foundation.dart';
+import '../../domain/entities/destination_entity.dart';
+import '../../domain/usecases/get_destinations_use_case.dart';
+
+class HomeController extends ChangeNotifier {
+  final GetDestinationsUseCase getDestinationsUseCase;
+
+  HomeController({required this.getDestinationsUseCase});
+
+  List<DestinationEntity> destinations = [];
+  bool isLoading = false;
+
+  Future<void> loadDestinations() async {
+    isLoading = true;
+    notifyListeners();
+
+    destinations = await getDestinationsUseCase.call(null);
+
+    isLoading = false;
+    notifyListeners();
+  }
+}

--- a/lib/features/home/presentation/pages/home_page.dart
+++ b/lib/features/home/presentation/pages/home_page.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../controllers/home_controller.dart';
+import '../../domain/usecases/get_destinations_use_case.dart';
+import 'home_view.dart';
+
+class HomePage extends StatelessWidget {
+  const HomePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider(
+      create: (_) => HomeController(
+        getDestinationsUseCase: context.read<GetDestinationsUseCase>(),
+      )..loadDestinations(),
+      child: const HomeView(),
+    );
+  }
+}

--- a/lib/features/home/presentation/pages/home_view.dart
+++ b/lib/features/home/presentation/pages/home_view.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../controllers/home_controller.dart';
+import '../widgets/destination_card.dart';
+
+class HomeView extends StatefulWidget {
+  const HomeView({super.key});
+
+  @override
+  State<HomeView> createState() => _HomeViewState();
+}
+
+class _HomeViewState extends State<HomeView> {
+  @override
+  Widget build(BuildContext context) {
+    final controller = context.watch<HomeController>();
+
+    if (controller.isLoading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('추천 여행지')),
+      body: ListView.builder(
+        itemCount: controller.destinations.length,
+        itemBuilder: (context, index) {
+          final d = controller.destinations[index];
+          return DestinationCard(title: d.title, imageUrl: d.imageUrl);
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/home/presentation/widgets/destination_card.dart
+++ b/lib/features/home/presentation/widgets/destination_card.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+
+class DestinationCard extends StatelessWidget {
+  final String title;
+  final String imageUrl;
+
+  const DestinationCard({super.key, required this.title, required this.imageUrl});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      height: 160,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(12),
+        image: DecorationImage(
+          image: AssetImage(imageUrl),
+          fit: BoxFit.cover,
+        ),
+      ),
+      child: Container(
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(12),
+          gradient: LinearGradient(
+            colors: [Colors.black.withOpacity(0.4), Colors.transparent],
+            begin: Alignment.bottomCenter,
+            end: Alignment.topCenter,
+          ),
+        ),
+        alignment: Alignment.bottomLeft,
+        padding: const EdgeInsets.all(12),
+        child: Text(
+          title,
+          style: const TextStyle(
+            color: Colors.white,
+            fontSize: 18,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add home feature with Clean Architecture layers
- provide recommended destinations using dummy data
- inject home dependencies through `app_providers`
- integrate HomePage into `AppScaffold`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68770831ffe0832083d96715a49f584b